### PR TITLE
Separate docs and linting checks from main CI pipeline

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,29 @@
+name: docs
+
+on:
+  push:
+    branches:
+      - develop
+      - master
+  pull_request:
+
+jobs:
+  run:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: 3.7
+
+    timeout-minutes: 30
+
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions/setup-python@master
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run:  pip install tox
+    - name: Generate Documentation
+      run: tox -e docs

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,33 @@
+name: lint
+
+on:
+  push:
+    branches:
+      - develop
+      - master
+  pull_request:
+
+jobs:
+  run:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: 3.7
+
+    timeout-minutes: 30
+
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions/setup-python@master
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run:  pip install tox
+    - name: Code style check
+      run: |
+        tox -e black
+        tox -e flake8
+    - name: Static type check
+      run: tox -e mypy

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # pddl
 
-![pddl CI](https://github.com/whitemech/pddl/workflows/pddl%20CI/badge.svg)
+![test](https://github.com/whitemech/pddl/workflows/test/badge.svg)
+![lint](https://github.com/whitemech/pddl/workflows/lint/badge.svg)
+![docs](https://github.com/whitemech/pddl/workflows/docs/badge.svg)
 [![](https://img.shields.io/badge/docs-mkdocs-9cf)](https://www.mkdocs.org/)
 [![](https://img.shields.io/badge/status-development-orange.svg)](https://img.shields.io/badge/status-development-orange.svg)
 [![codecov](https://codecov.io/gh/whitemech/pddl/branch/master/graph/badge.svg?token=FG3ATGP5P5)](https://codecov.io/gh/whitemech/pddl)


### PR DESCRIPTION
## Proposed changes

Separate docs and linting checks from main CI pipeline.

The main reason is that it prevents the pipeline to fail just because of the linting or static checks, hence helping the development.
Moreover, it is easy to refer just to docs and linting checks in the README by having ad-hoc badges.

## Fixes

n/a

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../blob/master/CONTRIBUTING.md) doc
- [X] I am making a pull request against the `develop` branch (left side). Also you should start your branch off our `develop`.
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works

## Further comments

n/a