### PR TITLE
Return type annotation for Problem and Domain transformers. Fixed requirements type annotation in DomainTransformer.

### DIFF
--- a/pddl/parser/domain.py
+++ b/pddl/parser/domain.py
@@ -464,6 +464,6 @@ class DomainParser:
         """Call."""
         sys.tracebacklimit = 0  # noqa
         tree = self._parser.parse(text)
-        sys.tracebacklimit = None  # noqa
+        sys.tracebacklimit = None  # type: ignore
         formula = self._transformer.transform(tree)
         return formula

--- a/pddl/parser/domain.py
+++ b/pddl/parser/domain.py
@@ -12,7 +12,7 @@
 
 """Implementation of the PDDL domain parser."""
 import sys
-from typing import Dict, Optional, Set, Tuple
+from typing import Any, Dict, Optional, Set, Tuple
 
 from lark import Lark, ParseError, Transformer
 
@@ -48,7 +48,7 @@ from pddl.parser.typed_list_parser import TypedListParser
 from pddl.requirements import Requirements, _extend_domain_requirements
 
 
-class DomainTransformer(Transformer):
+class DomainTransformer(Transformer[Any, Domain]):
     """Domain Transformer."""
 
     def __init__(self, *args, **kwargs):
@@ -59,8 +59,8 @@ class DomainTransformer(Transformer):
         self._predicates_by_name: Dict[str, Predicate] = {}
         self._functions_by_name: Dict[str, FunctionExpression] = {}
         self._current_parameters_by_name: Dict[str, Variable] = {}
-        self._requirements: Set[str] = set()
-        self._extended_requirements: Set[str] = set()
+        self._requirements: Set[Requirements] = set()
+        self._extended_requirements: Set[Requirements] = set()
 
     def start(self, args):
         """Entry point."""
@@ -460,7 +460,7 @@ class DomainParser:
             _domain_parser_lark, parser="lalr", import_paths=[PARSERS_DIRECTORY]
         )
 
-    def __call__(self, text):
+    def __call__(self, text: str) -> Domain:
         """Call."""
         sys.tracebacklimit = 0  # noqa
         tree = self._parser.parse(text)

--- a/pddl/parser/domain.py
+++ b/pddl/parser/domain.py
@@ -11,7 +11,6 @@
 #
 
 """Implementation of the PDDL domain parser."""
-import sys
 from typing import Any, Dict, Optional, Set, Tuple
 
 from lark import Lark, ParseError, Transformer
@@ -20,7 +19,7 @@ from pddl.action import Action
 from pddl.core import Domain
 from pddl.custom_types import name
 from pddl.exceptions import PDDLMissingRequirementError, PDDLParsingError
-from pddl.helpers.base import assert_
+from pddl.helpers.base import assert_, call_parser
 from pddl.logic.base import And, ExistsCondition, ForallCondition, Imply, Not, OneOf, Or
 from pddl.logic.effects import AndEffect, Forall, When
 from pddl.logic.functions import Assign, Decrease, Divide
@@ -462,8 +461,4 @@ class DomainParser:
 
     def __call__(self, text: str) -> Domain:
         """Call."""
-        sys.tracebacklimit = 0  # noqa
-        tree = self._parser.parse(text)
-        sys.tracebacklimit = None  # type: ignore
-        formula = self._transformer.transform(tree)
-        return formula
+        return call_parser(text, self._parser, self._transformer)

--- a/pddl/parser/problem.py
+++ b/pddl/parser/problem.py
@@ -246,6 +246,6 @@ class ProblemParser:
         """Call."""
         sys.tracebacklimit = 0  # noqa
         tree = self._parser.parse(text)
-        sys.tracebacklimit = None  # noqa
+        sys.tracebacklimit = None  # type: ignore
         formula = self._transformer.transform(tree)
         return formula

--- a/pddl/parser/problem.py
+++ b/pddl/parser/problem.py
@@ -11,14 +11,13 @@
 #
 
 """Implementation of the PDDL problem parser."""
-import sys
 from typing import Any, Dict
 
 from lark import Lark, ParseError, Transformer
 
 from pddl.core import Problem
 from pddl.exceptions import PDDLParsingError
-from pddl.helpers.base import assert_
+from pddl.helpers.base import assert_, call_parser
 from pddl.logic.base import And, Not
 from pddl.logic.functions import Divide
 from pddl.logic.functions import EqualTo as FunctionEqualTo
@@ -242,10 +241,6 @@ class ProblemParser:
             _problem_parser_lark, parser="lalr", import_paths=[PARSERS_DIRECTORY]
         )
 
-    def __call__(self, text) -> Problem:
+    def __call__(self, text: str) -> Problem:
         """Call."""
-        sys.tracebacklimit = 0  # noqa
-        tree = self._parser.parse(text)
-        sys.tracebacklimit = None  # type: ignore
-        formula = self._transformer.transform(tree)
-        return formula
+        return call_parser(text, self._parser, self._transformer)

--- a/pddl/parser/problem.py
+++ b/pddl/parser/problem.py
@@ -12,7 +12,7 @@
 
 """Implementation of the PDDL problem parser."""
 import sys
-from typing import Dict
+from typing import Any, Dict
 
 from lark import Lark, ParseError, Transformer
 
@@ -42,7 +42,7 @@ from pddl.parser.symbols import BINARY_COMP_SYMBOLS, Symbols
 from pddl.requirements import Requirements
 
 
-class ProblemTransformer(Transformer):
+class ProblemTransformer(Transformer[Any, Problem]):
     """Problem Transformer."""
 
     def __init__(self):
@@ -242,7 +242,7 @@ class ProblemParser:
             _problem_parser_lark, parser="lalr", import_paths=[PARSERS_DIRECTORY]
         )
 
-    def __call__(self, text):
+    def __call__(self, text) -> Problem:
         """Call."""
         sys.tracebacklimit = 0  # noqa
         tree = self._parser.parse(text)

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,6 @@ commands =
     flake8 pddl tests
 
 [testenv:mypy]
-skip_install = True
 deps =
     mypy>=1.3.0,<1.4.0
     types-click>=7.1.8,<7.2.0


### PR DESCRIPTION
## Proposed changes

A few type annotations. I didn't add any annotations to `parse_problem` and `parse_domain`, because I didn't want to `Domain` and `Problem` imports to the `__init__.py`.

## Fixes

Adds return type annotation for Problem and Domain transformers, by specifying that type parameter when subclassing `Transformer`. Also annotated that `Domain.__call__` and `Problem.__call__` return `Domain` and `Problem`, respectively.

Fixed `_requirements` type annotation in `DomainTransformer`.
## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

I ran the tests and got the following output. I can't tell from this where mypy/evaluation failed. 

```
========================================================= 2117 passed in 347.71s (0:05:47) =========================================================
.pkg: _exit> python /home/johnny/mambaforge/envs/scoping_new_z3/lib/python3.10/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
  check-copyright: OK (0.18=setup[0.14]+cmd[0.05] seconds)
  black-check: OK (3.71=setup[2.67]+cmd[1.03] seconds)
  isort-check: OK (1.97=setup[1.73]+cmd[0.24] seconds)
  docs: OK (10.27=setup[9.62]+cmd[0.65] seconds)
  flake8: OK (4.05=setup[3.20]+cmd[0.86] seconds)
  mypy: FAIL code 1 (7.70=setup[5.04]+cmd[2.65] seconds)
  py37: SKIP (0.12 seconds)
  py38: SKIP (0.01 seconds)
  py39: SKIP (0.01 seconds)
  py310: OK (362.15=setup[13.69]+cmd[348.46] seconds)
  evaluation failed :( (390.27 seconds)
```

