### PR TITLE
Fixing two subtle bugs with numerics in problem files.

### DIFF
--- a/pddl/parser/common.lark
+++ b/pddl/parser/common.lark
@@ -58,7 +58,7 @@ DECREASE: "decrease"
 MAXIMIZE: "maximize"
 MINIMIZE: "minimize"
 TOTAL_COST: "total-cost"
-NUMBER: /[0-9]+(.[0-9]+)*/
+NUMBER: /[0-9]+(\.[0-9]+)*/
 
 // available requirements
 STRIPS: ":strips"

--- a/pddl/parser/problem.lark
+++ b/pddl/parser/problem.lark
@@ -27,7 +27,7 @@ goal:  LPAR GOAL gd_name RPAR
 gd_name:    atomic_formula_name
        |    LPAR NOT atomic_formula_name RPAR
        |    LPAR AND gd_name* RPAR
-       |    LPAR binary_comp f_exp f_exp RPAR
+       |    LPAR binary_comp metric_f_exp metric_f_exp RPAR
 
 metric_spec: LPAR METRIC optimization metric_f_exp RPAR
 

--- a/tests/test_parser/test_problem.py
+++ b/tests/test_parser/test_problem.py
@@ -111,3 +111,43 @@ def test_problem_init_predicate_repetition_name_allowed() -> None:
     """
     )
     ProblemParser()(problem_str)
+
+def test_numeric_comparison_in_goal() -> None:
+    """Try to parse a goal with a numeric condition."""
+    problem_str = dedent(
+        """
+    (define (problem hello-3-times)
+        (:domain hello-world-functions)
+
+        (:init
+            ; if this was undefined, some planners would not assumed `0`
+            (= (hello_counter jimmy) 0)
+        )
+
+        (:goal
+            (> 5 3)
+        )
+    )
+    """
+    )
+    ProblemParser()(problem_str)
+
+def test_numeric_function_comparison_in_goal() -> None:
+    """Try to parse a goal with a numeric condition and function."""
+    problem_str = dedent(
+        """
+    (define (problem hello-3-times)
+        (:domain hello-world-functions)
+
+        (:init
+            ; if this was undefined, some planners would not assumed `0`
+            (= (hello_counter jimmy) 0)
+        )
+
+        (:goal
+            (>= (hello_counter jimmy) 3)
+        )
+    )
+    """
+    )
+    ProblemParser()(problem_str)


### PR DESCRIPTION
## Fixes

Does two important things to address #99 and another bug found:

1. `NUMBER` was matching on anything with a space (so `5 3` was a single number)
2. The f-expressions in the problem file were pointing back to the domain definition, and thus trying to wrap in Variables.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## Further comments

Don't have the time to let the tests run tonight on my laptop. Will let the online ones go ahead, and if there are any hangups, you can consider this PR a WIP that I'll fix.
