### PR TITLE
fix: remove type checking in Predicate.__call__

### DIFF
--- a/pddl/logic/predicates.py
+++ b/pddl/logic/predicates.py
@@ -70,10 +70,6 @@ class Predicate(Atomic):
     def __call__(self, *terms: Term):
         """Replace terms."""
         assert_(len(terms) == self.arity, "Number of terms not correct.")
-        assert_(
-            all(t1.type_tags == t2.type_tags for t1, t2 in zip(self.terms, terms)),
-            "Types of replacements is not correct.",
-        )
         return Predicate(self.name, *terms)
 
     def __str__(self) -> str:


### PR DESCRIPTION
## Proposed changes

This commit removes a check on the types of the new terms passed as arguments to Predicate.__call__. The reason is that the check is not "complete": for example, the check returns false when a new term whose types are a subset of the types of the term being replaced, while the correct result is true.

More fundamentally, the problem is that the class Predicate, in its current state, does not have information on the type hierarchy of the domain the predicate belongs to. Having this check here adds more problems than benefits. The final type check will be performed when instantiating the Domain class while leaving the flexibility to the user to instantiate temporary predicate objects, even with terms whose type is incompatible with the target type hierarchy of the PDDL domain.

Therefore, rather than having a half-working feature, it is better to remove it altogether. The idea is still relevant, but it may require a distinction between 'PredicateDefinition' (which has a pointer to the domain or the type hierarchy) and 'Predicate' (the actual instance of the predicate definition, with only constants).


## Fixes

Partially addresses issues in #98 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## Further comments

Given that there are different overlapping issues regarding validation, I propose to address them in a separate refactoring as attempted in https://github.com/AI-Planning/pddl/pull/84 (relatively soon). 