### PR TITLE
Problems domain check requirements bugfix

### DIFF
--- a/pddl/core.py
+++ b/pddl/core.py
@@ -296,7 +296,7 @@ class Problem:
             "Domain names don't match.",
         )
         validate(
-            self._requirements is None or self._requirements == domain.requirements,
+            self._requirements is None or self._requirements <= domain.requirements,
             "Requirements don't match.",
         )
         types = Types(domain.types, domain.requirements, skip_checks=True)  # type: ignore

--- a/tests/test_problem.py
+++ b/tests/test_problem.py
@@ -32,6 +32,7 @@ from pddl.logic.functions import (
 from pddl.logic.helpers import constants, variables
 from pddl.logic.predicates import Predicate
 from pddl.parser.symbols import Symbols
+from pddl.requirements import Requirements
 from tests.conftest import pddl_objects_problems
 
 
@@ -163,5 +164,13 @@ def test_problem_check_domain_name_case_insensitive_match() -> None:
     """Test domain name check accepts names that only differ by case."""
     domain = Domain("simple_domain")
     problem = Problem("simple_problem", domain_name="SIMPLE_DOMAIN")
+
+    problem.check(domain)
+
+
+def test_problem_check_domain_requirements_match() -> None:
+    """Test problem requirements are subset of a domain's requirements."""
+    domain = Domain("simple_domain", requirements=[Requirements.STRIPS, Requirements.EQUALITY])
+    problem = Problem("simple_problem", domain_name="simple_domain", requirements=[Requirements.STRIPS])
 
     problem.check(domain)

--- a/tests/test_problem.py
+++ b/tests/test_problem.py
@@ -170,7 +170,13 @@ def test_problem_check_domain_name_case_insensitive_match() -> None:
 
 def test_problem_check_domain_requirements_match() -> None:
     """Test problem requirements are subset of a domain's requirements."""
-    domain = Domain("simple_domain", requirements=[Requirements.STRIPS, Requirements.EQUALITY])
-    problem = Problem("simple_problem", domain_name="simple_domain", requirements=[Requirements.STRIPS])
+    domain = Domain(
+        "simple_domain", requirements=[Requirements.STRIPS, Requirements.EQUALITY]
+    )
+    problem = Problem(
+        "simple_problem",
+        domain_name="simple_domain",
+        requirements=[Requirements.STRIPS],
+    )
 
     problem.check(domain)


### PR DESCRIPTION
Problem's requirements validation should check that the problem's requirements are a subset of the domain's instead of equals to.

## Proposed changes

Replace == with <= in Problem.check() for requirements validation.

## Fixes
Issue #189

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
