### PR TITLE
Fix: Plan instantiation not respecting types of action parameters

### DIFF
--- a/pddl/core.py
+++ b/pddl/core.py
@@ -416,7 +416,17 @@ class Plan:
             if action_name not in name_to_schema:
                 raise ValueError(f"Action {action_name} not found in domain.")
             action_schema = name_to_schema[action_name]
-            instantiated_action = action_schema.instantiate(parameters)
+            typed_parameters = []
+            for untyped_param, action_param in zip(
+                parameters, action_schema.parameters
+            ):
+                type_tag = (
+                    next(iter(action_param.type_tags))
+                    if len(action_param.type_tags) == 1
+                    else None
+                )
+                typed_parameters.append(Constant(untyped_param.name, type_tag))
+            instantiated_action = action_schema.instantiate(typed_parameters)
             ret.append(instantiated_action)
         return ret
 

--- a/pddl/helpers/base.py
+++ b/pddl/helpers/base.py
@@ -131,7 +131,7 @@ def _typed_parameters(parameters) -> str:
         if i > 0:
             result += " "
         if p.type_tags:
-            result += f"?{p.name} - {' '.join(map(str, p.type_tags))}"
+            result += f"{str(p)} - {' '.join(map(str, p.type_tags))}"
         else:
             result += str(p)
     return result.strip()

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -132,10 +132,12 @@ def test_bad_plan_objects():
 def test_plan_instantiation_eq():
     """Test Issue #176."""
     domain = parse_domain(BLOCKSWORLD_FILES / "domain.pddl")
-    b1, b2 = constants("badblock1 badblock2")
+    b1, b2 = constants("badblock1 badblock2", type_="block")
     plan = Plan(actions=[("pick-up", [b1, b2])])
     instantiated_plan = plan.instantiate(domain)
     assert len(instantiated_plan) == 1
     assert instantiated_plan[0].name == "pick-up"
     assert instantiated_plan[0].parameters == (b1, b2)
+    assert instantiated_plan[0].parameters[0].type_tags == b1.type_tags
+    assert instantiated_plan[0].parameters[1].type_tags == b2.type_tags
     assert "badblock" not in str(domain)


### PR DESCRIPTION
## Proposed changes

Type the parameters used in instantiating actions in `Plan.instantiate()` using the existing `type_tags`  variables of the to-be instantiated actions.

### Demonstration:
```py
from pddl import parse_plan, parse_domain, parse_problem
from pddl.logic.predicates import Predicate
from pddl.logic.base import Not, And

problem = parse_problem("tests/fixtures/pddl_files/barman-sequential-optimal/p01.pddl")
domain = parse_domain("tests/fixtures/pddl_files/barman-sequential-optimal/domain.pddl")
plan = parse_plan("tests/fixtures/pddl_files/barman-sequential-optimal/p01.plan")

problem.domain = domain
actions = plan.instantiate(domain)
    
print("preconditions:")
for action in actions:
    for effect in action.precondition.operands if isinstance(action.precondition, And) else [action.precondition]:
        pred = effect._arg if isinstance(effect, Not) else effect
        print_terms = []
        for term in pred.terms:
            print_terms.append(f"{term.name}: {term.type_tag}")
        print(str(pred), *print_terms)

print("\n\neffects:")
for action in actions:
    for effect in action.effect.operands if isinstance(action.effect, And) else [action.effect]:
        pred = effect._arg if isinstance(effect, Not) else effect
        if not isinstance(pred, Predicate): continue
        print_terms = []
        for term in pred.terms:
            print_terms.append(f"{term.name}: {term.type_tag}")
        print(str(pred), *print_terms)
```

Without the fix (truncated):
```
preconditions:
(ontable shaker1) shaker1: None
(handempty left) left: None
(ontable shot4) shot4: None
(handempty right) right: None
(holding left shaker1) left: None shaker1: None
...


effects:
(ontable shaker1) shaker1: None
(handempty left) left: None
(holding left shaker1) left: None shaker1: None
(ontable shot4) shot4: None
(handempty right) right: None
(holding right shot4) right: None shot4: None
(holding left shaker1) left: None shaker1: None
...
```

With the fix (truncated):
```
preconditions:
(ontable shaker1) shaker1: container
(handempty left) left: hand
(ontable shot4) shot4: container
(handempty right) right: hand
(holding left shaker1) left: hand shaker1: container
(holding right shot4) right: hand shot4: shot
...


effects:
(ontable shaker1) shaker1: container
(handempty left) left: hand
(holding left shaker1) left: hand shaker1: container
(ontable shot4) shot4: container
(handempty right) right: hand
...
```

## Fixes

When you instantiate a plan, the actions are instantiated with terms without `type_tags`, even if the variables in the actions do. 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## Further comments
I'm looking for feedback for if this is something the `Plan.instantiate()`  should do, if it's better to do it somewhere else, or if the terms are meant to be untyped.