### PR TITLE
Fix #100: support subtraction in preconditions in domains + new UnaryMinus class

### DIFF
--- a/pddl/_validation.py
+++ b/pddl/_validation.py
@@ -30,6 +30,7 @@ from pddl.logic.functions import (
     FunctionExpression,
     NumericFunction,
     NumericValue,
+    UnaryMinus,
 )
 from pddl.logic.predicates import DerivedPredicate, EqualTo
 from pddl.logic.terms import Term
@@ -255,6 +256,11 @@ class TypeChecker:
     def _(self, binary_function: BinaryFunction) -> None:
         """Check types annotations of a PDDL numeric binary operator."""
         self.check_type(binary_function.operands)
+
+    @check_type.register
+    def _(self, unary_minus: UnaryMinus) -> None:
+        """Check types annotations of a PDDL numeric unary operator."""
+        self.check_type(unary_minus.operand)
 
     @check_type.register
     def _(self, equal_to: EqualTo) -> None:

--- a/pddl/logic/base.py
+++ b/pddl/logic/base.py
@@ -136,6 +136,14 @@ class Atomic(Formula):
 
 
 class BinaryOpMetaclass(type):
+    """Base metaclass for binary operators."""
+
+    def __call__(cls, *args, **kwargs):
+        """Init the subclass object."""
+        return super().__call__(*args, **kwargs)
+
+
+class BinaryLogicOpMetaclass(BinaryOpMetaclass):
     """Metaclass to simplify monotone operator instantiations."""
 
     _absorbing: Optional[Formula] = None
@@ -152,7 +160,7 @@ class BinaryOpMetaclass(type):
         return super(BinaryOpMetaclass, cls).__call__(*operands, **kwargs)
 
 
-class And(BinaryOp, metaclass=BinaryOpMetaclass):
+class And(BinaryOp, metaclass=BinaryLogicOpMetaclass):
     """And operator."""
 
     _absorbing = False
@@ -160,7 +168,7 @@ class And(BinaryOp, metaclass=BinaryOpMetaclass):
     SYMBOL = "and"
 
 
-class Or(BinaryOp, metaclass=BinaryOpMetaclass):
+class Or(BinaryOp, metaclass=BinaryLogicOpMetaclass):
     """Or operator."""
 
     _absorbing = True

--- a/pddl/logic/functions.py
+++ b/pddl/logic/functions.py
@@ -349,6 +349,41 @@ class Decrease(BinaryFunction):
         super().__init__(*operands)
 
 
+class UnaryMinus(FunctionExpression):
+    """Unary Minus operator: (- <f_exp>)."""
+
+    SYMBOL = Symbols.MINUS
+
+    def __init__(self, operand: FunctionExpression):
+        """Initialize UnaryMinus operator with exactly one operand."""
+        self._operand = operand
+
+    @property
+    def operand(self) -> FunctionExpression:
+        """Get the operand."""
+        return self._operand
+
+    def instantiate(self, mapping: Mapping[Variable, Term]) -> "UnaryMinus":
+        """Instantiate the formula with a mapping from variables to terms."""
+        return UnaryMinus(cast(FunctionExpression, self.operand.instantiate(mapping)))
+
+    def __str__(self) -> str:
+        """Get the string representation."""
+        return f"({self.SYMBOL.value} {self.operand})"
+
+    def __repr__(self) -> str:
+        """Get an unambiguous string representation."""
+        return f"{type(self).__name__}({repr(self.operand)})"
+
+    def __eq__(self, other):
+        """Compare with another object."""
+        return isinstance(other, UnaryMinus) and self.operand == other.operand
+
+    def __hash__(self) -> int:
+        """Compute the hash of the object."""
+        return hash((type(self), self.operand))
+
+
 class Minus(BinaryFunction, metaclass=BinaryOpMetaclass):
     """Minus operator."""
 

--- a/pddl/parser/_update_type_tags.py
+++ b/pddl/parser/_update_type_tags.py
@@ -18,7 +18,12 @@ from typing import FrozenSet, Mapping, Optional
 
 from pddl.custom_types import namelike
 from pddl.logic.base import BinaryOp, Formula, QuantifiedCondition, UnaryOp
-from pddl.logic.functions import BinaryFunction, NumericFunction, NumericValue
+from pddl.logic.functions import (
+    BinaryFunction,
+    NumericFunction,
+    NumericValue,
+    UnaryMinus,
+)
 from pddl.logic.predicates import EqualTo as EqualToPredicate
 from pddl.logic.predicates import Predicate
 from pddl.logic.terms import Term, Variable
@@ -117,6 +122,14 @@ def _update_type_tags_binary_function(
         new_operand = _update_type_tags(operand, var_to_types)
         new_operands.append(new_operand)
     return formula.__class__(*new_operands)
+
+
+@_update_type_tags.register
+def _update_type_tags_unary_minus(
+    formula: UnaryMinus, var_to_types: Mapping[str, Optional[FrozenSet[namelike]]]
+):
+    new_operand = _update_type_tags(formula.operand, var_to_types)
+    return formula.__class__(new_operand)
 
 
 def _replace_term_with_type_tags_if_var(

--- a/pddl/parser/domain.py
+++ b/pddl/parser/domain.py
@@ -50,6 +50,7 @@ from pddl.logic.functions import (
     ScaleDown,
     ScaleUp,
     Times,
+    UnaryMinus,
 )
 from pddl.logic.predicates import DerivedPredicate, EqualTo, Predicate
 from pddl.logic.terms import Constant, Variable
@@ -451,7 +452,13 @@ class DomainTransformer(Transformer[Any, Domain]):
             return args[0]
         op = None
         if args[1] == Symbols.MINUS.value:
-            op = Minus
+            n = len(args[2:-1])
+            if n == 1:
+                op = UnaryMinus
+            elif n == 2:
+                op = Minus
+            else:
+                raise PDDLParsingError(f"MINUS symbol used with {n} args")
         if args[1] == Symbols.PLUS.value:
             op = Plus
         if args[1] == Symbols.TIMES.value:

--- a/pddl/parser/grammar.lark
+++ b/pddl/parser/grammar.lark
@@ -79,7 +79,7 @@ num_literal: NUMBER
 f_exp:      num_literal
       |     LPAR binary_op f_exp f_exp RPAR
       |     LPAR multi_op f_exp f_exp+ RPAR
-      |     LPAR MINUS f_exp RPAR
+      |     LPAR MINUS f_exp+ RPAR
       |     f_head
 
 f_head:     NAME
@@ -132,7 +132,7 @@ metric_spec: LPAR METRIC optimization metric_f_exp RPAR
 
 metric_f_exp: LPAR binary_op metric_f_exp metric_f_exp RPAR
             | LPAR multi_op metric_f_exp metric_f_exp+ RPAR
-            | LPAR MINUS metric_f_exp RPAR
+            | LPAR MINUS metric_f_exp+ RPAR
             | basic_function_term
             | NUMBER
 

--- a/pddl/parser/problem.py
+++ b/pddl/parser/problem.py
@@ -29,6 +29,7 @@ from pddl.logic.functions import (
     NumericValue,
     Plus,
     Times,
+    UnaryMinus,
 )
 from pddl.logic.predicates import EqualTo, Predicate
 from pddl.logic.terms import Constant
@@ -192,7 +193,13 @@ class ProblemTransformer(Transformer[Any, Problem]):
             return args[0]
         op = None
         if args[1] == Symbols.MINUS.value:
-            op = Minus
+            n = len(args[2:-1])
+            if n == 1:
+                op = UnaryMinus
+            elif n == 2:
+                op = Minus
+            else:
+                raise PDDLParsingError(f"MINUS symbol used with {n} args")
         if args[1] == Symbols.PLUS.value:
             op = Plus
         if args[1] == Symbols.TIMES.value:

--- a/scripts/whitelist.py
+++ b/scripts/whitelist.py
@@ -30,6 +30,7 @@ _update_type_tags_predicate  # unused function (pddl/parser/_update_type_tags.py
 _update_type_tags_numeric_function  # unused function (pddl/parser/_update_type_tags.py:93)
 _update_type_tags_numeric_value  # unused function (pddl/parser/_update_type_tags.py:103)
 _update_type_tags_binary_function  # unused function (pddl/parser/_update_type_tags.py:110)
+_update_type_tags_unary_minus  # unused function (pddl/parser/_update_type_tags.py:128)
 _._predicates_by_name  # unused attribute (pddl/parser/domain.py:58)
 _._functions_by_name  # unused attribute (pddl/parser/domain.py:59)
 _.start  # unused method (pddl/parser/domain.py:64)

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -31,8 +31,10 @@ from pddl.logic.functions import (
     Increase,
     LesserEqualThan,
     LesserThan,
+    Minus,
     NumericFunction,
     NumericValue,
+    UnaryMinus,
 )
 from pddl.logic.helpers import constants, variables
 from pddl.logic.predicates import DerivedPredicate, Predicate
@@ -287,3 +289,40 @@ def test_derived_predicate_type_not_available() -> None:
         f"available types {{'{my_type}'}}",
     ):
         Domain("test", requirements={Requirements.TYPING}, derived_predicates={dp}, types=type_set)  # type: ignore
+
+
+def test_build_domain_with_unary_minus() -> None:
+    """Test a PDDL domain with unary minus in precondition and effect."""
+    f = NumericFunction("f1")
+    action = Action(
+        "action_1",
+        [],
+        precondition=GreaterEqualThan(NumericValue(0), UnaryMinus(f)),
+        effect=Increase(f, UnaryMinus(NumericValue(1))),
+    )
+    domain = Domain(
+        "domain_with_unary_minus",
+        requirements={Requirements.NUMERIC_FLUENTS},
+        functions={f: None},
+        actions={action},
+    )
+    assert domain
+
+
+def test_build_domain_with_binary_minus() -> None:
+    """Test a PDDL domain with binary minus in precondition and effect."""
+    f1 = NumericFunction("f1")
+    f2 = NumericFunction("f2")
+    action = Action(
+        "action_1",
+        [],
+        precondition=GreaterEqualThan(NumericValue(0), Minus(f1, f2)),
+        effect=Increase(f1, Minus(f2, NumericValue(1))),
+    )
+    domain = Domain(
+        "domain_with_binary_minus",
+        requirements={Requirements.NUMERIC_FLUENTS},
+        functions={f1: None, f2: None},
+        actions={action},
+    )
+    assert domain

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -14,14 +14,19 @@
 
 import pytest
 
+from pddl.logic.base import And, Or
 from pddl.logic.functions import (
+    Divide,
     Metric,
     Minus,
     NumericFunction,
     NumericValue,
+    Plus,
+    Times,
     UnaryMinus,
 )
 from pddl.logic.helpers import constants, variables
+from pddl.logic.predicates import Predicate
 from pddl.parser.symbols import Symbols
 
 
@@ -187,3 +192,92 @@ class TestUnaryMinus:
         a = constants("a")[0]
         unary_minus = UnaryMinus(NumericFunction("func", x))
         assert unary_minus.instantiate({x: a}) == UnaryMinus(NumericFunction("func", a))
+
+
+class TestNumericOperatorStructure:
+    """Test that numeric operators preserve operand structure (no flattening/dedup)."""
+
+    def setup_method(self):
+        """Set up the tests."""
+        self.f = NumericFunction("f")
+        self.g = NumericFunction("g")
+
+    def test_right_nested_minus_preserved(self):
+        """Right-nested binary minus keeps its tree structure."""
+        expr = Minus(self.f, Minus(self.f, NumericValue(2)))
+        assert str(expr) == "(- (f) (- (f) 2))"
+        assert isinstance(expr.operands[0], NumericFunction)
+        assert isinstance(expr.operands[1], Minus)
+        assert isinstance(expr.operands[1].operands[0], NumericFunction)
+        assert isinstance(expr.operands[1].operands[1], NumericValue)
+        assert expr.operands[1].operands == (self.f, NumericValue(2))
+
+    def test_left_nested_minus_preserved(self):
+        """Left-nested binary minus keeps its tree structure and order."""
+        expr = Minus(Minus(NumericValue(2), NumericValue(3)), NumericValue(1))
+        assert str(expr) == "(- (- 2 3) 1)"
+        assert isinstance(expr.operands[0], Minus)
+        assert isinstance(expr.operands[0].operands[0], NumericValue)
+        assert isinstance(expr.operands[0].operands[1], NumericValue)
+        assert isinstance(expr.operands[1], NumericValue)
+
+    def test_nested_plus_not_flattened(self):
+        """Nested plus is not auto-flattened."""
+        expr = Plus(Plus(self.f, self.g), self.f)
+        assert str(expr) == "(+ (+ (f) (g)) (f))"
+        assert isinstance(expr.operands[0], Plus)
+        assert isinstance(expr.operands[0].operands[0], NumericFunction)
+        assert isinstance(expr.operands[0].operands[1], NumericFunction)
+        assert isinstance(expr.operands[1], NumericFunction)
+
+    def test_nary_plus_accepted(self):
+        """Plus still accepts more than two operands."""
+        expr = Plus(self.f, self.g, self.f)
+        assert len(expr.operands) == 3
+        assert str(expr) == "(+ (f) (g) (f))"
+        assert isinstance(expr, Plus)
+        assert isinstance(expr.operands[0], NumericFunction)
+        assert isinstance(expr.operands[1], NumericFunction)
+        assert isinstance(expr.operands[2], NumericFunction)
+
+    def test_nested_times_preserved(self):
+        """Nested times keeps its tree structure."""
+        expr = Times(Times(self.f, self.g), self.f)
+        assert str(expr) == "(* (* (f) (g)) (f))"
+        assert isinstance(expr, Times)
+        assert isinstance(expr.operands[0], Times)
+        assert isinstance(expr.operands[0].operands[0], NumericFunction)
+        assert isinstance(expr.operands[0].operands[1], NumericFunction)
+        assert isinstance(expr.operands[1], NumericFunction)
+
+    def test_nested_divide_preserved(self):
+        """Nested divide keeps its tree structure."""
+        expr = Divide(NumericValue(1), Divide(NumericValue(2), NumericValue(3)))
+        assert str(expr) == "(/ 1 (/ 2 3))"
+        assert isinstance(expr.operands[1], Divide)
+        assert isinstance(expr.operands[0], NumericValue)
+        assert isinstance(expr.operands[1].operands[0], NumericValue)
+        assert isinstance(expr.operands[1].operands[1], NumericValue)
+
+
+class TestLogicOperatorSimplification:
+    """That that And/Or keep their monotone simplification behaviour."""
+
+    def setup_method(self):
+        """Set up the tests."""
+        self.p = Predicate("p")
+        self.q = Predicate("q")
+
+    def test_and_idempotency(self):
+        """And(a, a) collapses to a."""
+        assert And(self.p, self.p) == self.p
+
+    def test_or_idempotency(self):
+        """Or(a, a) collapses to a."""
+        assert Or(self.p, self.p) == self.p
+
+    def test_and_flattening(self):
+        """Nested And is flattened (associative)."""
+        r = Predicate("f")
+        expr = And(self.p, And(self.q, r))
+        assert tuple(expr.operands) == (self.p, self.q, r)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -14,7 +14,13 @@
 
 import pytest
 
-from pddl.logic.functions import Metric, NumericFunction, NumericValue
+from pddl.logic.functions import (
+    Metric,
+    Minus,
+    NumericFunction,
+    NumericValue,
+    UnaryMinus,
+)
 from pddl.logic.helpers import constants, variables
 from pddl.parser.symbols import Symbols
 
@@ -135,3 +141,49 @@ class TestNumericValue:
     def test_value(self):
         """Test the name getter."""
         assert self.numeric_value.value == 3
+
+
+class TestUnaryMinus:
+    """Test the unary minus operator."""
+
+    def setup_method(self):
+        """Set up the tests."""
+        self.function = NumericFunction("func")
+        self.unary_minus = UnaryMinus(self.function)
+
+    def test_operand(self):
+        """Test the operand getter."""
+        assert self.unary_minus.operand == self.function
+
+    def test_symbol(self):
+        """Test the symbol getter."""
+        assert self.unary_minus.SYMBOL == Symbols.MINUS
+
+    def test_to_equal(self):
+        """Test the equal operator."""
+        other = UnaryMinus(NumericFunction("func"))
+        assert self.unary_minus == other
+
+    def test_not_equal_to_minus(self):
+        """Test that UnaryMinus is distinct from binary Minus."""
+        binary_minus = Minus(self.function, NumericFunction("other"))
+        assert self.unary_minus != binary_minus
+
+    def test_to_str(self):
+        """Test the str operator."""
+        assert str(self.unary_minus) == f"({Symbols.MINUS.value} {self.function})"
+
+    def test_to_repr(self):
+        """Test the repr operator."""
+        assert repr(self.unary_minus) == f"UnaryMinus({repr(self.function)})"
+
+    def test_hash(self):
+        """Test the hash operator."""
+        assert hash(self.unary_minus) == hash(UnaryMinus(NumericFunction("func")))
+
+    def test_instantiate(self):
+        """Test the instantiate method."""
+        x = variables("x")[0]
+        a = constants("a")[0]
+        unary_minus = UnaryMinus(NumericFunction("func", x))
+        assert unary_minus.instantiate({x: a}) == UnaryMinus(NumericFunction("func", a))

--- a/tests/test_parser/test_domain.py
+++ b/tests/test_parser/test_domain.py
@@ -23,8 +23,10 @@ from pddl.logic.functions import (
     BinaryFunction,
     GreaterEqualThan,
     Increase,
+    Minus,
     NumericFunction,
     NumericValue,
+    UnaryMinus,
 )
 from pddl.logic.predicates import EqualTo, Predicate
 from pddl.logic.terms import Variable
@@ -695,3 +697,144 @@ def test_number_parsing() -> None:
     assert type(g_effect.operands[1]) is NumericValue
     assert type(g_effect.operands[1].value) is float
     assert g_effect.operands[1] == NumericValue(0.5)
+
+
+def test_unary_minus_in_precondition() -> None:
+    """Check parsing of unary minus in a numeric precondition."""
+    domain_str = dedent("""
+    (define (domain test)
+        (:requirements :numeric-fluents)
+        (:functions (f))
+        (:action a
+            :parameters ()
+            :precondition (>=0 (- (f)))
+            :effect (and (increase (f) 1))
+        )
+    )
+    """)
+    action = next(iter(DomainParser()(domain_str).actions))
+    precondition = action.precondition
+    assert isinstance(precondition, BinaryFunction)
+    unary_minus = precondition.operands[1]
+    assert isinstance(unary_minus, UnaryMinus)
+    assert isinstance(unary_minus.operand, NumericFunction)
+    assert str(unary_minus) == f"({Symbols.MINUS.value} (f))"
+
+
+def test_unary_minus_in_numeric_effect() -> None:
+    """Check parsing of unary minus in a numeric effect."""
+    domain_str = dedent("""
+    (define (domain test)
+        (:requirements :numeric-fluents)
+        (:functions (f))
+        (:action a
+            :parameters ()
+            :precondition (>= (f) 0)
+            :effect (and (increase (f) (- 1)))
+        )
+    )
+    """)
+    action = next(iter(DomainParser()(domain_str).actions))
+    effect = action.effect
+    assert isinstance(effect, BinaryFunction)  # increase
+    unary_minus = effect.operands[1]
+    assert isinstance(unary_minus, UnaryMinus)
+    assert unary_minus.operand == NumericValue(1)
+
+
+def test_binary_minus_in_precondition() -> None:
+    """Check parsing of binary minus in a numeric precondition."""
+    domain_str = dedent("""
+    (define (domain test)
+        (:requirements :numeric-fluents)
+        (:functions (f) (g))
+        (:action a
+            :parameters ()
+            :precondition (>= 0 (- (f) (g)))
+            :effect (and (increase (f) 1))
+        )
+    )
+    """)
+    action = next(iter(DomainParser()(domain_str).actions))
+    precondition = action.precondition
+    assert isinstance(precondition, BinaryFunction)
+    binary_minus = precondition.operands[1]
+    assert isinstance(binary_minus, Minus)
+    assert len(binary_minus.operands) == 2
+    assert isinstance(binary_minus.operands[0], NumericFunction)
+    assert isinstance(binary_minus.operands[1], NumericFunction)
+
+
+def test_binary_minus_in_numeric_effect() -> None:
+    """Check parsing of binary minus in a numeric effect."""
+    domain_str = dedent("""
+    (define (domain test)
+        (:requirements :numeric-fluents)
+        (:functions (f) (g))
+        (:action a
+            :parameters ()
+            :precondition (>= (f) 0)
+            :effect (and (increase (f) (- (g) 1)))
+        )
+    )
+    """)
+    action = next(iter(DomainParser()(domain_str).actions))
+    effect = action.effect
+    assert isinstance(effect, BinaryFunction)  # increase
+    binary_minus = effect.operands[1]
+    assert isinstance(binary_minus, Minus)
+    assert len(binary_minus.operands) == 2
+    assert isinstance(binary_minus.operands[0], NumericFunction)
+    assert isinstance(binary_minus.operands[1], NumericValue)
+
+
+def test_minus_with_three_operands_not_allowed() -> None:
+    """Check that a minus expression with more than two operands is rejected."""
+    domain_str = dedent("""
+    (define (domain test)
+        (:requirements :numeric-fluents)
+        (:functions (f))
+        (:action a
+            :parameters ()
+            :precondition (>= 0 (- 1 2 3))
+            :effect (and (increase (f) 1))
+        )
+    )
+    """)
+    with pytest.raises(PDDLParsingError, match="MINUS symbol used with 3 args"):
+        DomainParser()(domain_str)
+
+
+def test_unary_minus_domain_round_trip() -> None:
+    """Check that a domain with unary minus round-trips through str()."""
+    domain_str = dedent("""
+    (define (domain test)
+        (:requirements :numeric-fluents)
+        (:functions (f))
+        (:action a
+            :parameters ()
+            :precondition (>= 0 (- (f)))
+            :effect (and (increase (f) (- 1)))
+        )
+    )
+    """)
+    domain = DomainParser()(domain_str)
+    assert DomainParser()(str(domain)) == domain
+
+
+def test_unary_minus_in_derived_predicate_condition() -> None:
+    """Check parsing of unary minus in a derived predicate condition."""
+    domain_str = dedent("""
+    (define (domain test)
+        (:requirements :numeric-fluents)
+        (:predicates (g))
+        (:functions (f))
+        (:derived (g)
+            (>= 0 (- (f)))
+        )
+    )
+    """)
+    axiom = next(iter(DomainParser()(domain_str).derived_predicates))
+    condition = axiom.condition
+    assert isinstance(condition, GreaterEqualThan)
+    assert isinstance(condition.operands[1], UnaryMinus)

--- a/tests/test_parser/test_domain.py
+++ b/tests/test_parser/test_domain.py
@@ -788,6 +788,31 @@ def test_binary_minus_in_numeric_effect() -> None:
     assert isinstance(binary_minus.operands[1], NumericValue)
 
 
+def test_nested_minus_in_precondition_preserved() -> None:
+    """Check that a nested binary minus is a precondition keeps its structure."""
+    domain_str = dedent("""
+    (define (domain test)
+        (:requirements :numeric-fluents)
+        (:functions (f))
+        (:action a
+            :parameters ()
+            :precondition (= (- (f) (- (f) 2)) 3)
+            :effect (and (increase (f) 1))
+        )
+    )
+    """)
+    action = next(iter(DomainParser()(domain_str).actions))
+    precondition = action.precondition
+    assert isinstance(precondition, BinaryFunction)
+    exp1 = precondition.operands[0]
+    assert str(exp1) == "(- (f) (- (f) 2))"
+    assert isinstance(exp1, Minus)
+    assert isinstance(exp1.operands[0], NumericFunction)
+    assert isinstance(exp1.operands[1], Minus)
+    assert isinstance(exp1.operands[1].operands[0], NumericFunction)
+    assert isinstance(exp1.operands[1].operands[1], NumericValue)
+
+
 def test_minus_with_three_operands_not_allowed() -> None:
     """Check that a minus expression with more than two operands is rejected."""
     domain_str = dedent("""

--- a/tests/test_parser/test_problem.py
+++ b/tests/test_parser/test_problem.py
@@ -22,8 +22,10 @@ from pddl.logic.functions import (
     EqualTo,
     GreaterEqualThan,
     GreaterThan,
+    Minus,
     NumericFunction,
     NumericValue,
+    UnaryMinus,
 )
 from pddl.logic.terms import Constant
 from pddl.parser.problem import ProblemParser
@@ -190,3 +192,57 @@ def test_numeric_function_equality_in_goal() -> None:
         EqualTo(NumericValue(3), NumericFunction("hello_counter", Constant("jimmy"))),
         EqualTo(NumericFunction("hello_counter", Constant("jammy")), NumericValue(5)),
     )
+
+
+def test_metric_unary_minus() -> None:
+    """Check parsing of a metric with unary minus."""
+    problem_str = dedent("""
+    (define (problem test-problem)
+        (:domain test-domain)
+        (:requirements :numeric-fluents)
+        (:init (= (f) 0))
+        (:goal (>= (f) 0))
+        (:metric minimize (- (f)))
+    )
+    """)
+    problem = ProblemParser()(problem_str)
+    assert problem.metric is not None
+    expression = problem.metric.expression
+    assert isinstance(expression, UnaryMinus)
+    assert isinstance(expression.operand, NumericFunction)
+
+
+def test_metric_binary_minus() -> None:
+    """Check parsing of a metric with binary minus."""
+    problem_str = dedent("""
+    (define (problem test-problem)
+        (:domain test-domain)
+        (:requirements :numeric-fluents)
+        (:init (= (f) 0))
+        (:goal (>= (f) 0))
+        (:metric minimize (- (f) 2))
+    )
+    """)
+    problem = ProblemParser()(problem_str)
+    assert problem.metric is not None
+    expression = problem.metric.expression
+    assert isinstance(expression, Minus)
+    assert len(expression.operands) == 2
+    assert isinstance(expression.operands[0], NumericFunction)
+    assert isinstance(expression.operands[1], NumericValue)
+
+
+def test_metric_with_three_operands_not_allowed() -> None:
+    """Check that a minus expression with more than two operands is rejected."""
+    problem_str = dedent("""
+    (define (problem test-problem)
+        (:domain test-domain)
+        (:requirements :numeric-fluents)
+        (:init (= (f) 0))
+        (:goal (>= (f) 0))
+        (:metric minimize (- (f) 2 3))
+    )
+    """)
+
+    with pytest.raises(PDDLParsingError, match="MINUS symbol used with 3 args"):
+        ProblemParser()(problem_str)

--- a/tests/test_parser/test_problem.py
+++ b/tests/test_parser/test_problem.py
@@ -232,6 +232,28 @@ def test_metric_binary_minus() -> None:
     assert isinstance(expression.operands[1], NumericValue)
 
 
+def test_metric_nested_minus() -> None:
+    """Check that a nested binary minus metric keeps its structure."""
+    problem_str = dedent("""
+    (define (problem test-problem)
+        (:domain test-domain)
+        (:requirements :numeric-fluents)
+        (:init (= (f) 0))
+        (:goal (>= (f) 0))
+        (:metric minimize (- (f) (- (f) 2)))
+    )
+    """)
+    problem = ProblemParser()(problem_str)
+    assert problem.metric is not None
+    expression = problem.metric.expression
+    assert isinstance(expression, Minus)
+    assert isinstance(expression.operands[0], NumericFunction)
+    assert isinstance(expression.operands[1], Minus)
+    assert isinstance(expression.operands[1].operands[0], NumericFunction)
+    assert isinstance(expression.operands[1].operands[1], NumericValue)
+    assert str(expression) == "(- (f) (- (f) 2))"
+
+
 def test_metric_with_three_operands_not_allowed() -> None:
     """Check that a minus expression with more than two operands is rejected."""
     problem_str = dedent("""

--- a/tests/test_problem.py
+++ b/tests/test_problem.py
@@ -28,6 +28,7 @@ from pddl.logic.functions import (
     LesserThan,
     Metric,
     NumericFunction,
+    UnaryMinus,
 )
 from pddl.logic.helpers import constants, variables
 from pddl.logic.predicates import Predicate
@@ -180,3 +181,15 @@ def test_problem_check_domain_requirements_match() -> None:
     )
 
     problem.check(domain)
+
+
+def test_build_problem_with_unary_minus_metric() -> None:
+    """Test a PDDL problem with a unary minus metric."""
+    total_cost = NumericFunction(Symbols.TOTAL_COST.value)
+    problem = Problem(
+        "simple_problem",
+        domain_name="simple_domain",
+        metric=Metric(UnaryMinus(total_cost)),
+    )
+    assert problem.metric is not None
+    assert isinstance(problem.metric.expression, UnaryMinus)


### PR DESCRIPTION
## Proposed changes

**TLDR**: Draft PR #104 addresses this issue with a different approach (negating via (-1 * x)); this PR supersedes it. Unary minus (- x) now parses to a real `UnaryMinus`, binary (- a b) parses to `Minus`, validation and type-tag propagation work, `str()` round-trips, and both are consistent across domains, problems, and special case of metrics.

1. `pddl/logic/functions.py` -> new UnaryMinus class  Previously (- x) had to be a one-arg Minus. 
Added a `UnaryMinus(FunctionExpression)` operator distinct from binary `Minus`

2. `pddl/parser/domain.py` -> `f_exp` rule
Fixed `f_exp` to disambiguate by operand count: n == 1 (UnaryMinus) and n == 2 (Minus), else Lark error. Added `UnaryMinus` import.

3. `pddl/parser/problem.py` -> `metric_f_exp` rule
Same bug in metrics: `(:metric minimize (- …))` that we forgot to catch. Mirror of the domain fix (it's the same n==1/n==2 branch + import) so easy fix.

4. `pddl/parser/grammar.lark` -> unary-minus grammar rule
*This was addressed by @marfvr *
Changed both `f_exp` and `metric_f_exp` from `LPAR MINUS f_exp RPAR` to `LPAR MINUS f_exp+ RPAR`. The old rule made LALR commit to unary minus, so binary `(- a b)` was unparseable (dead Minus branch). + lets both arities reach the transformer, which disambiguates.

- **Update (15/09/26)**: Changed `LPAR MINUS f_exp+ RPAR` with `LPAR MINUS f_exp RPAR` and `LPAR MINUS f_exp f_exp RPAR` in `pddl/parser/grammar.lark`. Lark now catches `n >= 3` parsing error. By doing this, we removed redundant `MINUS` from `binary_op` due to overloading of `UnaryMinus/Minus` classes. 

**IMPORTANT**
2nd commit: preserve nested structure for numeric operators. Split `BinaryOpMetaclass` (passthrough) from a new `BinaryLogicOpMetaclass` (flattening/dedup, used only by `And/Or`). Fixes silent flattening/dedup of `Minus/Divide/Plus/Times`, so nested expressions like `(- (f) (- (f) 2))` keep their tree structure.

## Fixes

Fixes https://github.com/AI-Planning/pddl/issues/100 and solves open PR https://github.com/AI-Planning/pddl/pull/104

Fixes silent flattening; associative `Plus/Multiply` still accept n-ary operands:

- `Plus(a, b, c)` --> `(+ a b c)`
- `Plus(Plus(a, b), c)` --> `(+ (+ a b) c)`

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works

## Further comments

This was a bug roadblock that had to be addressed before moving to the next step of `durative-actions`. I have added extended tests in `tests/test_parser/test_domain.py`, `tests/test_parser/test_problem.py`, as well as build tests: `tests/test_functions.py`, `tests/test_domain.py`, and `tests/test_problem.py`.

Any further stress testing is welcome!
